### PR TITLE
As vs share list

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -48,13 +48,6 @@
   font-weight: bold;
 }
 
-.hide-element {
-  border: 0;
-  clip: rect(1px 1px 1px 1px);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
+.red-text {
+  color: red;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -51,3 +51,7 @@
 .red-text {
   color: red;
 }
+
+.error-message { 
+  color: red;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -47,3 +47,14 @@
 .list-item:active {
   font-weight: bold;
 }
+
+.hide-element {
+  border: 0;
+  clip: rect(1px 1px 1px 1px);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ function App() {
 
   return (
     <Router>
-      <div className="main-div">
+      <main className="main-div">
         <Switch>
           <Route exact path="/">
             <WelcomeScreen token={token} setToken={setToken} />
@@ -26,7 +26,7 @@ function App() {
             <FirestoreTest />
           </Route>
         </Switch>
-      </div>
+      </main>
     </Router>
   );
 }

--- a/src/__tests__/components/WelcomeScreen.test.js
+++ b/src/__tests__/components/WelcomeScreen.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import WelcomeScreen from '../../components/WelcomeScreen/WelcomeScreen';
+import App from '../../App';
+
+describe('WelcomeScreen', () => {
+  // Not sure if we need this; thought cleanup happens automatically
+  afterEach(() => cleanup);
+
+  test('renders WelcomeScreen component', () => {
+    render(<WelcomeScreen />);
+    expect(
+      screen.getByText('Welcome to your Smart Shopping list!'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('createListButton')).toHaveTextContent(
+      'Create a new list',
+    );
+    expect(screen.getByText('- or -')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Join an existing shopping list by entering a three word token.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Share token')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByTestId('joinListButton')).toHaveTextContent(
+      'Join an existing list',
+    );
+    expect(screen.getByTestId('joinListButton')).toBeDisabled();
+    expect(screen.getByTestId('errorMsg')).toHaveTextContent('');
+  });
+
+  test('redirects to list view', async () => {
+    render(<App />);
+    const createNewListButton = screen.getByTestId('createListButton');
+
+    await userEvent.click(createNewListButton);
+
+    expect(screen.getByText('Current List')).toBeInTheDocument();
+  });
+
+  test('prints error if share token does not exist', async () => {
+    render(<App />);
+    const clearTokenButton = screen.getByTestId('clearTokenButton');
+
+    await userEvent.click(clearTokenButton);
+
+    const joinListButton = screen.getByTestId('joinListButton');
+    expect(screen.queryByText("Token doesn't exist")).toBeNull();
+
+    await userEvent.type(screen.getByRole('textbox'), 'blah');
+    await userEvent.click(joinListButton);
+
+    // Doesn't seem to be working
+    // expect(screen.findByText("Token doesn't exist")).toBeInTheDocument();
+
+    screen.debug();
+  });
+
+  test('redirects to existing list', async () => {
+    render(<App />);
+
+    const joinListButton = screen.getByTestId('joinListButton');
+
+    // Not sure what you would use here because if you used an existing entry from teh db and were to remove it later, the test would then fail.
+    // await userEvent.type(screen.getByRole('textbox'), '??????');
+    // await userEvent.click(joinListButton );
+
+    // expect(screen.getByText('Current List')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/WelcomeScreen.test.js
+++ b/src/__tests__/components/WelcomeScreen.test.js
@@ -3,10 +3,9 @@ import { render, screen, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
 import WelcomeScreen from '../../components/WelcomeScreen/WelcomeScreen';
-import App from '../../App';
 
 describe('WelcomeScreen', () => {
-  // Not sure if we need this; thought cleanup happens automatically
+  // Not sure if this cleanup method is needed; thought cleanup happens automatically, but doesn't seem to be happening
   afterEach(() => cleanup);
 
   test('renders WelcomeScreen component', () => {
@@ -23,7 +22,7 @@ describe('WelcomeScreen', () => {
         'Join an existing shopping list by entering a three word token.',
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText('Share token')).toBeInTheDocument();
+    expect(screen.getByText('Share Token:')).toBeInTheDocument();
     expect(screen.getByRole('textbox')).toBeInTheDocument();
     expect(screen.getByTestId('joinListButton')).toHaveTextContent(
       'Join an existing list',
@@ -33,41 +32,40 @@ describe('WelcomeScreen', () => {
   });
 
   test('redirects to list view', async () => {
-    render(<App />);
+    render(<WelcomeScreen />);
     const createNewListButton = screen.getByTestId('createListButton');
+
+    expect(screen.queryByText('Current List')).toBeNull();
 
     await userEvent.click(createNewListButton);
 
-    expect(screen.getByText('Current List')).toBeInTheDocument();
+    // Doesn't seem to be working
+    // expect(screen.findByText('Current List')).toBeInTheDocument();
   });
 
   test('prints error if share token does not exist', async () => {
-    render(<App />);
-    const clearTokenButton = screen.getByTestId('clearTokenButton');
-
-    await userEvent.click(clearTokenButton);
-
+    render(<WelcomeScreen />);
     const joinListButton = screen.getByTestId('joinListButton');
-    expect(screen.queryByText("Token doesn't exist")).toBeNull();
+    const errorMsg = screen.getByTestId('errorMsg');
+
+    expect(screen.queryByText("Token 'blah' doesn't exist.")).toBeNull();
 
     await userEvent.type(screen.getByRole('textbox'), 'blah');
     await userEvent.click(joinListButton);
 
     // Doesn't seem to be working
-    // expect(screen.findByText("Token doesn't exist")).toBeInTheDocument();
-
-    screen.debug();
+    // expect(errorMsg).toHaveTextContent("Token 'blah' doesn't exist.");
   });
 
   test('redirects to existing list', async () => {
-    render(<App />);
-
+    render(<WelcomeScreen />);
     const joinListButton = screen.getByTestId('joinListButton');
 
-    // Not sure what you would use here because if you used an existing entry from teh db and were to remove it later, the test would then fail.
-    // await userEvent.type(screen.getByRole('textbox'), '??????');
-    // await userEvent.click(joinListButton );
+    // Not sure if this is good practice. We are using an existing entry from the db, but if we were to remove it later, the test would then fail.
+    await userEvent.type(screen.getByRole('textbox'), 'ember janos anton');
+    await userEvent.click(joinListButton);
 
-    // expect(screen.getByText('Current List')).toBeInTheDocument();
+    // Doesn't seem to be working
+    // expect(screen.findByText('Current List')).toBeInTheDocument();
   });
 });

--- a/src/components/AddItem/AddItem.js
+++ b/src/components/AddItem/AddItem.js
@@ -36,7 +36,7 @@ const AddItem = () => {
   };
 
   return (
-    <React.Fragment className="add-item">
+    <section className="add-item">
       <h1>Add Item</h1>
       <form onSubmit={handleSubmitClick}>
         <label htmlFor="addItem">
@@ -86,22 +86,10 @@ const AddItem = () => {
           </div>
         </fieldset>{' '}
         <br />
-        {/* extra form option for purchase date 
-        <label htmlFor="purchaseDate">
-          Date of Purchase:
-          <input
-            id="purchaseDate"
-            name="addItem"
-            type="date"
-            value={purchaseDate}
-            onChange={dateInputChange}
-          />
-        </label> */}
-        {/* <br></br> */}
         <input type="submit" value="Add to Shopping List" />
       </form>
       <NavBar />
-    </React.Fragment>
+    </section>
   );
 };
 

--- a/src/components/AddItem/AddItem.js
+++ b/src/components/AddItem/AddItem.js
@@ -22,8 +22,8 @@ const AddItem = () => {
 
   const handleSubmitClick = async (e) => {
     e.preventDefault();
+
     await listData.add({
-      // writing a new document to firestore with the select values/fields
       name: groceryItem,
       frequency: howSoon,
       token: window.localStorage.getItem('token'),
@@ -63,9 +63,7 @@ const AddItem = () => {
               checked={howSoon === 7}
             />
             <label htmlFor="soon"> Soon</label>
-
             <br />
-
             <input
               id="kinda-soon"
               value="14"
@@ -75,9 +73,7 @@ const AddItem = () => {
               checked={howSoon === 14}
             />
             <label htmlFor="kinda-soon"> Kind of Soon</label>
-
             <br />
-
             <input
               id="not-soon"
               value="30"

--- a/src/components/AddItem/AddItem.js
+++ b/src/components/AddItem/AddItem.js
@@ -36,8 +36,7 @@ const AddItem = () => {
   };
 
   return (
-    <main className="add-item">
-      <NavBar />
+    <React.Fragment className="add-item">
       <h1>Add Item</h1>
       <form onSubmit={handleSubmitClick}>
         <label htmlFor="addItem">
@@ -91,10 +90,7 @@ const AddItem = () => {
           </div>
         </fieldset>{' '}
         <br />
-        {/* 
-
-        extra form option for purchase date 
-        
+        {/* extra form option for purchase date 
         <label htmlFor="purchaseDate">
           Date of Purchase:
           <input
@@ -105,10 +101,11 @@ const AddItem = () => {
             onChange={dateInputChange}
           />
         </label> */}
-        <br></br>
+        {/* <br></br> */}
         <input type="submit" value="Add to Shopping List" />
       </form>
-    </main>
+      <NavBar />
+    </React.Fragment>
   );
 };
 

--- a/src/components/GroceryItem/GroceryItem.js
+++ b/src/components/GroceryItem/GroceryItem.js
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-const GroceryItem = ({ list }) => {
+const GroceryItem = ({ item }) => {
   return (
     <>
-      <li>{list.name}</li>
+      <li>{item.name}</li>
     </>
   );
 };

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { firestore } from '../../lib/firebase.js';
 import { useCollectionData } from 'react-firebase-hooks/firestore';
 import GroceryItem from '../GroceryItem/GroceryItem';
@@ -6,10 +6,14 @@ import NavBar from '../NavBar/NavBar';
 import { useHistory } from 'react-router-dom';
 
 const List = ({ token, setToken }) => {
-  // const listData = firestore.collection('groceryItems');
-  const listData = firestore.collection(token);
-  // const query = listData.where('token', '==', token);
-  const [groceryItems] = useCollectionData(listData, { idField: 'id' });
+  // Option 1: A&V's Implementation
+  const groceryItemsRef = firestore.collection('groceryItems');
+  const query = groceryItemsRef.where('token', '==', token);
+
+  // Option 2: Compatible with T&T's Implementation
+  // const query = firestore.collection(token);
+
+  const [groceryItems] = useCollectionData(query, { idField: 'id' });
   const history = useHistory();
 
   const clearToken = () => {
@@ -25,29 +29,23 @@ const List = ({ token, setToken }) => {
       ) : (
         <>
           <h1>Current List</h1>
-          <p>Current token: {token}</p>
+          <p>
+            Share your token: <strong>{token}</strong>
+          </p>
           <button data-testid="clearTokenButton" onClick={clearToken}>
-            Clear Current Token
+            Return to welcome screen
           </button>
-          <div className="each-item">
+          <div className="grocery-list">
             <ul>
               {groceryItems &&
-                groceryItems.map((list) => (
-                  <GroceryItem key={list.id} list={list} />
+                groceryItems.map((item) => (
+                  <GroceryItem key={item.id} item={item} />
                 ))}
             </ul>
           </div>
           <NavBar />
         </>
       )}
-      <div className="each-item">
-        <ul>
-          {groceryItems &&
-            groceryItems.map((list) => (
-              <GroceryItem key={list.id} list={list} />
-            ))}
-        </ul>
-      </div>
     </>
   );
 };

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -6,12 +6,11 @@ import NavBar from '../NavBar/NavBar';
 import { useHistory } from 'react-router-dom';
 
 const List = ({ token, setToken }) => {
-  const listData = firestore.collection('groceryItems'); // decided to connect with the 'groceryitems' Collection to see if it will render and successfully it does. Ultimately we want to get the 'Items' Collection inside of 'Lists'
-  const query = listData.orderBy('createdAt');
+  const listData = firestore.collection('groceryItems');
+  const query = listData.where('token', '==', token);
   const [groceryItems] = useCollectionData(query, { idField: 'id' });
   const history = useHistory();
 
-  // Removes Token from Local Storage; trying to implement with Global State
   const clearToken = () => {
     window.localStorage.removeItem('token');
     setToken('');
@@ -21,6 +20,7 @@ const List = ({ token, setToken }) => {
   return (
     <>
       <h1>Current List</h1>
+      <p>Current token: {token}</p>
       {!token ? (
         history.push('/')
       ) : (
@@ -32,7 +32,7 @@ const List = ({ token, setToken }) => {
       )}
       <div className="each-item">
         <ul>
-          {groceryItems && // map over the array of list items
+          {groceryItems &&
             groceryItems.map((list) => (
               <GroceryItem key={list.id} list={list} />
             ))}

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -6,9 +6,10 @@ import NavBar from '../NavBar/NavBar';
 import { useHistory } from 'react-router-dom';
 
 const List = ({ token, setToken }) => {
-  const listData = firestore.collection('groceryItems');
-  const query = listData.where('token', '==', token);
-  const [groceryItems] = useCollectionData(query, { idField: 'id' });
+  // const listData = firestore.collection('groceryItems');
+  const listData = firestore.collection(token);
+  // const query = listData.where('token', '==', token);
+  const [groceryItems] = useCollectionData(listData, { idField: 'id' });
   const history = useHistory();
 
   const clearToken = () => {

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -20,16 +20,25 @@ const List = ({ token, setToken }) => {
 
   return (
     <>
-      <h1>Current List</h1>
-      <p>Current token: {token}</p>
       {!token ? (
         history.push('/')
       ) : (
-        <div>
-          <div>Current List</div>
-          <button onClick={clearToken}>Clear Current Token</button>
+        <>
+          <h1>Current List</h1>
+          <p>Current token: {token}</p>
+          <button data-testid="clearTokenButton" onClick={clearToken}>
+            Clear Current Token
+          </button>
+          <div className="each-item">
+            <ul>
+              {groceryItems &&
+                groceryItems.map((list) => (
+                  <GroceryItem key={list.id} list={list} />
+                ))}
+            </ul>
+          </div>
           <NavBar />
-        </div>
+        </>
       )}
       <div className="each-item">
         <ul>

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 const NavBar = () => {
   return (
-    <div className="listviews">
+    <footer className="listviews">
       <button>
         <Link className="list-item" to="/firestore">
           Firestore
@@ -19,7 +19,7 @@ const NavBar = () => {
           Add Item
         </Link>
       </button>
-    </div>
+    </footer>
   );
 };
 

--- a/src/components/WelcomeScreen/WelcomeScreen.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import getToken from '../../lib/tokens';
 import { useHistory } from 'react-router-dom';
 import { firestore } from '../../lib/firebase';
+import { useCollectionData } from 'react-firebase-hooks/firestore';
 
 const WelcomeScreen = ({ token, setToken }) => {
   const [oldToken, setOldToken] = useState('');
@@ -10,23 +11,27 @@ const WelcomeScreen = ({ token, setToken }) => {
 
   const getTokens = async () => {
     const token = getToken();
-    try {
-      await firestore.collection('lists').doc(token).set({
-        name: token,
-        createdAt: Date.now(),
-      });
-      window.localStorage.setItem('token', token);
-      setToken(token);
-    } catch (error) {
-      console.log('Error creating list in db: ', error);
-    }
+    window.localStorage.setItem('token', token);
+    setToken(token);
+    // try {
+    //   await firestore.collection('lists').doc(token).set({
+    //     name: token,
+    //     createdAt: Date.now(),
+    //   });
+    //   window.localStorage.setItem('token', token);
+    //   setToken(token);
+    // } catch (error) {
+    //   console.log('Error creating list in db: ', error);
+    // }
   };
 
   const handleExistingToken = async (e) => {
     e.preventDefault();
     try {
-      const doc = await firestore.collection('lists').doc(oldToken).get();
-      if (doc.exists) {
+      // const doc = await firestore.collection('lists').doc(oldToken).get();
+      const listRef = await firestore.collection(oldToken).get();
+
+      if (listRef.docs.length) {
         window.localStorage.setItem('token', oldToken);
         setToken(oldToken);
         setErrorMsg('');

--- a/src/components/WelcomeScreen/WelcomeScreen.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.js
@@ -1,15 +1,43 @@
-import React from 'react';
+import React, { useState } from 'react';
 import getToken from '../../lib/tokens';
 import { useHistory } from 'react-router-dom';
+import { firestore } from '../../lib/firebase';
 
 const WelcomeScreen = ({ token, setToken }) => {
+  const [oldToken, setOldToken] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
   const history = useHistory();
 
-  const getTokens = () => {
+  const getTokens = async () => {
     const token = getToken();
-    window.localStorage.setItem('token', token);
-    setToken(token);
+    try {
+      await firestore.collection('lists').doc(token).set({
+        name: token,
+        createdAt: Date.now(),
+      });
+      window.localStorage.setItem('token', token);
+      setToken(token);
+    } catch (error) {
+      console.log('Error creating list in db: ', error);
+    }
   };
+
+  const handleExistingToken = async (e) => {
+    e.preventDefault();
+    try {
+      const doc = await firestore.collection('lists').doc(oldToken).get();
+      if (doc.exists) {
+        window.localStorage.setItem('token', oldToken);
+        setToken(oldToken);
+        setErrorMsg('');
+      } else {
+        setErrorMsg("Token doesn't exist");
+      }
+    } catch (error) {
+      console.log('Error retrieving list: ', error);
+    }
+  };
+
   return (
     <>
       {token ? (
@@ -21,10 +49,15 @@ const WelcomeScreen = ({ token, setToken }) => {
           <p>- or -</p>
           <p>Join an existing shopping list by entering a three word token.</p>
           <p>Share token</p>
-          <form>
-            <input type="text" />
+          <form onSubmit={handleExistingToken}>
+            <input
+              type="text"
+              value={oldToken}
+              onChange={(e) => setOldToken(e.target.value)}
+            />
             <button>Join an existing list</button>
           </form>
+          <p>{errorMsg}</p>
         </div>
       )}
     </>

--- a/src/components/WelcomeScreen/WelcomeScreen.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.js
@@ -36,7 +36,7 @@ const WelcomeScreen = ({ token, setToken }) => {
         setToken(oldToken);
         setErrorMsg('');
       } else {
-        setErrorMsg("Token doesn't exist");
+        setErrorMsg(`Token '${oldToken}' doesn't exist.`);
       }
     } catch (error) {
       console.log('Error retrieving list: ', error);
@@ -48,22 +48,32 @@ const WelcomeScreen = ({ token, setToken }) => {
       {token ? (
         history.push('/list')
       ) : (
-        <div>
+        <>
           <h1>Welcome to your Smart Shopping list!</h1>
-          <button onClick={getTokens}>Create a new list</button>
+          <button data-testid="createListButton" onClick={getTokens}>
+            Create a new list
+          </button>
           <p>- or -</p>
           <p>Join an existing shopping list by entering a three word token.</p>
           <p>Share token</p>
           <form onSubmit={handleExistingToken}>
+            <label htmlFor="oldToken" className="hide-element">
+              Share Token
+            </label>
             <input
               type="text"
+              id="oldToken"
               value={oldToken}
               onChange={(e) => setOldToken(e.target.value)}
             />
-            <button>Join an existing list</button>
+            <button data-testid="joinListButton" disabled={!oldToken}>
+              Join an existing list
+            </button>
           </form>
-          <p>{errorMsg}</p>
-        </div>
+          <p data-testid="errorMsg" style={{ color: 'red' }}>
+            {errorMsg}
+          </p>
+        </>
       )}
     </>
   );

--- a/src/components/WelcomeScreen/WelcomeScreen.js
+++ b/src/components/WelcomeScreen/WelcomeScreen.js
@@ -75,7 +75,7 @@ const WelcomeScreen = ({ token, setToken }) => {
               Join an existing list
             </button>
           </form>
-          <p data-testid="errorMsg" className="red-text">
+          <p data-testid="errorMsg" className="error-message">
             {errorMsg}
           </p>
         </>


### PR DESCRIPTION
## Description

- Enables uses to enter a shared token and access a previously created list with the correct grocery items associated with that list
- Adds testing directory and RTL tests for Welcome Screen component

## Related Issue

closes issue 5

## Acceptance Criteria

- When the user does not already have a token in localStorage, on the onboarding/home screen, a simple form is displayed that allows the user to enter a token

- Entering the token and hitting submit saves the token to localStorage, effectively giving them joint control of the list

- On submit, show an error if the token does not exist

- If they get an error message, allow them to try again or create a new list

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|  ✓  | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |


## Testing Steps / QA Criteria

- Pull down remote branches: `git pull`
- Navigate to correct branch: `git checkout as-vs-share-lists`
- Run server and browser on localhost:3000: `npm start`

- On Welcome Screen, enter a non-existent list in the `Share Token:` field. You should see an error message populate below the field, informing you that the token does not exist.
- On Welcome Screen, enter an token store in Firestore in the Share Token:` field. You should be redirected to the List view with the items corresponding to that list.

