### PR TITLE
Fix for particles that prevent to click on elements behind

### DIFF
--- a/src/components/Particles/Particles.js
+++ b/src/components/Particles/Particles.js
@@ -9,6 +9,10 @@ export default () => (
       left: 0,
       width: '100%',
       height: '100%',
+      // Prevents any mouse interactions with the particles wrapper
+      pointerEvents: 'none',
+      // Also, puts the particles wrapper behind the rest of the content (extra guard)
+      zIndex: -1,
     }}
   >
     <Particles


### PR DESCRIPTION
## Description

Fixes an issue that prevented to use the mouse on any part of the main content after introducing the Particles component.

## Acceptance Criteria

All the buttons and form elements should be clickable using the mouse.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![particles-before](https://user-images.githubusercontent.com/843075/120115542-20668200-c152-11eb-8192-fd4f2800c95b.gif)

### After

![particles](https://user-images.githubusercontent.com/843075/120115549-278d9000-c152-11eb-8bbb-1362fe41ed44.gif)

## Testing Steps / QA Criteria

1. Navigate to `/list`.
2. Click on `Add item`.
3. Type in any item in the textfield.
4. Select one of the options in `How soon will you buy this again?` using your mouse.
5. Click on `Add to shopping list`.
6. Go to `/list` and verify that the new item has been added to the list.

